### PR TITLE
add WineGE(7-29,7-31) and ProtonGE(7-37)

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -95,6 +95,14 @@ caffe-6.23:
 
 # Wine GE
 # -----------------------
+wine-ge-7-31:
+  Category: runners
+  Sub-category: wine
+  Channel: stable
+wine-ge-7-29:
+  Category: runners
+  Sub-category: wine
+  Channel: stable
 wine-ge-7-28:
   Category: runners
   Sub-category: wine
@@ -390,6 +398,10 @@ vaniglia-21.1.0-cx:
 
 # Proton GE
 # -----------------------
+GE-Proton7-37:
+  Category: runners
+  Sub-category: proton
+  Channel: stable
 GE-Proton7-35:
   Category: runners
   Sub-category: proton

--- a/runners/proton/GE-Proton7-37.yml
+++ b/runners/proton/GE-Proton7-37.yml
@@ -1,0 +1,8 @@
+Name: GE-Proton7-37
+Provider: gloriouseggroll
+Channel: stable
+File:
+- file_name: GE-Proton7-37.tar.gz
+  url: https://github.com/GloriousEggroll/proton-ge-custom/releases/download/GE-Proton7-37/GE-Proton7-37.tar.gz
+  file_checksum: c5fc73fba97e7dc165309ec08c06c419
+  rename: GE-Proton7-37.tar.gz

--- a/runners/wine/wine-ge-7-29.yml
+++ b/runners/wine/wine-ge-7-29.yml
@@ -1,0 +1,13 @@
+Name: wine-ge-7-29
+Provider: gloriouseggroll
+Channel: stable
+File:
+- file_name: wine-lutris-GE-Proton7-29-x86_64.tar.xz
+  url: https://github.com/GloriousEggroll/wine-ge-custom/releases/download/GE-Proton7-29/wine-lutris-GE-Proton7-29-x86_64.tar.xz 
+  file_checksum: 077a5548a533e17f9d1c9f8a0e9dcd02 
+  rename: wine-ge-7-29.tar.xz
+
+Post:
+- action: rename
+  source: lutris-GE-Proton7-29
+  dest: wine-ge-7-29

--- a/runners/wine/wine-ge-7-31.yml
+++ b/runners/wine/wine-ge-7-31.yml
@@ -1,0 +1,13 @@
+Name: wine-ge-7-31
+Provider: gloriouseggroll
+Channel: stable
+File:
+- file_name: wine-lutris-GE-Proton7-31-x86_64.tar.xz
+  url: https://github.com/GloriousEggroll/wine-ge-custom/releases/download/GE-Proton7-31/wine-lutris-GE-Proton7-31-x86_64.tar.xz
+  file_checksum: a2dc1cc87fa8406c0e88ce1b735a78ac
+  rename: wine-ge-7-31.tar.xz
+
+Post:
+- action: rename
+  source: lutris-GE-Proton7-31
+  dest: wine-ge-7-31


### PR DESCRIPTION
Added new Wine-GE builds: 7-29 and 7-31  
Added new ProtonGE build: 7-37

I skipped WineGE 7-30 and ProtonGE 7-36 since they don't contain FSR patch - that could create some unnecessary confusion on Bottles side.


## Type of change
- [x] New component
- [ ] Manifest fix
- [ ] Other

# Whas This Tested Using a [Local Repository](https://maintainers.usebottles.com/Testing)?
- [x] Yes
- [ ] No
