### PR TITLE
Add support for the Wine-GE-7-32 runner

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -95,6 +95,10 @@ caffe-6.23:
 
 # Wine GE
 # -----------------------
+wine-ge-7-32:
+  Category: runners
+  Sub-category: wine
+  Channel: stable
 wine-ge-7-31:
   Category: runners
   Sub-category: wine

--- a/runners/wine/wine-ge-7-32.yml
+++ b/runners/wine/wine-ge-7-32.yml
@@ -1,0 +1,13 @@
+Name: wine-ge-7-32
+Provider: gloriouseggroll
+Channel: stable
+File:
+- file_name: wine-lutris-GE-Proton7-32-x86_64.tar.xz
+  url: https://github.com/GloriousEggroll/wine-ge-custom/releases/download/GE-Proton7-32/wine-lutris-GE-Proton7-32-x86_64.tar.xz
+  file_checksum: cfb7d9ec83de05de7eafc8712f9c2042
+  rename: wine-ge-7-32.tar.xz
+
+Post:
+- action: rename
+  source: lutris-GE-Proton7-32
+  dest: wine-ge-7-32


### PR DESCRIPTION
# Description

Add support for the latest Wine GE 7-32 release: https://github.com/GloriousEggroll/wine-ge-custom/releases/tag/GE-Proton7-32

## Type of change
- [x] New component
- [ ] Manifest fix
- [ ] Other

## Was This Tested Using a [Local Repository](https://maintainers.usebottles.com/Testing)?
- [ ] Yes
- [x] No
