### PR TITLE
Revert "add Soda 7.0-8" commit

### DIFF
--- a/input_files/3-soda.yml
+++ b/input_files/3-soda.yml
@@ -1,11 +1,8 @@
-soda-7.0-8:
-  Category: runners
-  Sub-category: wine
-  Channel: stable
 soda-7.0-7:
   Category: runners
   Sub-category: wine
   Channel: stable
+  Date: '1667427951'
 soda-7.0-4:
   Category: runners
   Sub-category: wine


### PR DESCRIPTION
It is not necessary (already handled automatically), and it will break the CI on its next run because of the missing `Date` field
(Additionally, the soda-7.0-8.yml file hasn't been created, so it would not have worked anyway)