### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/pull-components.yml
+++ b/.github/workflows/pull-components.yml
@@ -229,7 +229,8 @@ jobs:
           done
 
   finish:
-    needs: pull
+    needs: [prepare, pull]
+    if: always() && needs.prepare.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Recently, a new beta version of Proton-GE has been released : [GE-Proton7-51-diablo_4_beta](https://github.com/GloriousEggroll/proton-ge-custom/releases/tag/GE-Proton7-51-diablo_4_beta). As it does not fit into the expected name regex for a Proton-GE release, the CI rightfully fails to pick it up for its PR. However, I've been a bit over conservative and made the CI stop entirely when a failure to pull one component is detected, this PR attempts to correct this behavior.