### PR TITLE
New component: dxvk-gplasync

### DIFF
--- a/51.6.yml
+++ b/51.6.yml
@@ -1384,6 +1384,10 @@ dxvk-1.7.3:
 
 # ./input_files/15-dxvk-async.yml
 # -----------------------
+dxvk-gplasync-2.2-4:
+  Category: dxvk
+  Channel: stable
+  Date: '1687361985'
 dxvk-async-2.0:
   Category: dxvk
   Channel: stable

--- a/dxvk/dxvk-gplasync-2.2-4.yml
+++ b/dxvk/dxvk-gplasync-2.2-4.yml
@@ -1,0 +1,10 @@
+Name: dxvk-gplasync-2.2-4
+Provider: Ph42oN
+Maintainer: Ph42oN
+Channel: stable
+File:
+- file_name: dxvk-gplasync-v2.2-4.tar.gz
+  url: https://gitlab.com/Ph42oN/dxvk-gplasync/-/raw/a3b55d5ebf14d2bd20397c80887a6dc1af23a0b7/releases/dxvk-gplasync-v2.2-4.tar.gz
+  file_checksum: 785fd7b0b6ee7743e8a8504d60713f9f
+  file_size: 7880919
+  rename: dxvk-gplasync-v2.2-4.tar.gz

--- a/dxvk/dxvk-gplasync-2.2-4.yml
+++ b/dxvk/dxvk-gplasync-2.2-4.yml
@@ -1,6 +1,6 @@
 Name: dxvk-gplasync-2.2-4
 Provider: Ph42oN
-Maintainer: Ph42oN
+Maintainer: koplo199
 Channel: stable
 File:
 - file_name: dxvk-gplasync-v2.2-4.tar.gz

--- a/index.yml
+++ b/index.yml
@@ -1384,6 +1384,10 @@ dxvk-1.7.3:
 
 # ./input_files/15-dxvk-async.yml
 # -----------------------
+dxvk-gplasync-2.2-4:
+  Category: dxvk
+  Channel: stable
+  Date: '1687361985'
 dxvk-async-2.0:
   Category: dxvk
   Channel: stable

--- a/input_files/15-dxvk-async.yml
+++ b/input_files/15-dxvk-async.yml
@@ -1,3 +1,7 @@
+dxvk-gplasync-2.2-4:
+  Category: dxvk
+  Channel: stable
+  Date: '1687361985'
 dxvk-async-2.0:
   Category: dxvk
   Channel: stable


### PR DESCRIPTION
It seems dxvk-async isn't maintained anymore, a fork has been created (https://github.com/Sporif/dxvk-async/issues/64#issuecomment-1441560713) which supports the latest dxvk version in addition of allowing the use of async and gpl at the same time. Added as an unstable/experimental component.

## Type of change
- [x] New component
- [ ] Manifest fix
- [ ] Other

## Was this tested using a [Local Repository](https://maintainers.usebottles.com/Testing)?
- [x] Yes
- [ ] No
