### PR TITLE
fix: Unstable revisions numbering

### DIFF
--- a/input_files/update_yml_entries.sh
+++ b/input_files/update_yml_entries.sh
@@ -84,7 +84,7 @@ if [ "$newer" -eq 0 ]; then
 fi
 
 if [ "$channel" = "unstable" ] && [ "$latest_channel" = "unstable" ]; then
-    if [[ $latest =~ .*-([[:digit:]])-[[:alnum:]]{7} ]]; then
+    if [[ $latest =~ .*-([[:digit:]]+)-[[:alnum:]]{7} ]]; then
         revision="${BASH_REMATCH[1]}"
         commit_sha=${component_name: -7}
         ((revision=$revision+1))


### PR DESCRIPTION
Fix the unstable builds revision numbering. The regex was wrong causing the revision to wrap after `10`, as showcased [here](https://github.com/bottlesdevs/components/compare/0bcc77fcb990f6e7fcb95fa4258aa446c2d700ff..7375b75a86cc3625afa1debe31f7ffb35d1fd26b#diff-de02621f89e124f163ad302cf680474978558a4880048fe02ba30be88461cc31)