### PR TITLE
ci: select x86_64 asset when upstream ships multi-arch releases

### DIFF
--- a/.github/workflows/pull-components.yml
+++ b/.github/workflows/pull-components.yml
@@ -126,7 +126,7 @@ jobs:
             else
               asset_name=$(gh release view "$latest_release" --json assets -q ".[] | .[$i] | .name" -R ${{ matrix.components.repo }})
             fi
-            if [[ "$asset_name" =~ ${{ matrix.components.name-prefix }}.*[0-9]+${{ matrix.components.name-suffix }}\.tar.* ]]; then
+            if [[ "$asset_name" =~ ${{ matrix.components.name-prefix }}.*[0-9]+${{ matrix.components.name-suffix }}\.tar.* ]] && [[ ! "$asset_name" =~ (aarch64|arm64) ]]; then
               found=true
             fi
           done


### PR DESCRIPTION
## Problem
Fix for #542 Since GE-Proton11-1, GloriousEggroll publishes an `-aarch64` build alongside
the x86_64 one on each release. The asset-selection loop in
`pull-components.yml` stops at the first asset matching
`<name-prefix>...[0-9]+<name-suffix>.tar.*`, and the aarch64 tarball is
returned first, so the importer selects `GE-Proton11-1-aarch64.tar.gz` — the
wrong architecture. This is what's currently blocking #542 (flagged there by
@jntesteves).

## Why not a `-x86_64` name-suffix
The x86_64 build keeps the legacy **unsuffixed** name (`GE-Proton11-1.tar.gz`);
there is no `-x86_64` asset to match, so adding a suffix would break selection
with "Cannot find a corresponding asset name."

## Fix
Skip `aarch64`/`arm64` assets in the selection loop so it falls through to the
x86_64 build. Bottles only ships x86_64 runners, so this is safe, and it also
future-proofs the identically-configured `wine-ge-custom` row.

## Verification
Simulated the loop against the real GE-Proton11-1 asset list:
- before: `GE-Proton11-1-aarch64.tar.gz`
- after:  `GE-Proton11-1.tar.gz`

Regression-checked single-asset (GE-Proton10-34), `-x86_64`-suffixed (CachyOS),
and arch-less (dxvk) rows, all of which are unchanged.

Once merged, the next scheduled `pull-components` run will regenerate the
GE-Proton11 entry in #542 with the correct x86_64 asset.
