### PR TITLE
Add component ge-proton11-1

### DIFF
--- a/63.2.yml
+++ b/63.2.yml
@@ -641,6 +641,11 @@ vaniglia-21.1.0-cx:
 
 # ./input_files/10-GE-Proton.yml
 # -----------------------
+ge-proton11-1:
+  Category: runners
+  Sub-category: proton
+  Channel: stable
+  Date: '1782269772'
 ge-proton10-34:
   Category: runners
   Sub-category: proton

--- a/index.yml
+++ b/index.yml
@@ -641,6 +641,11 @@ vaniglia-21.1.0-cx:
 
 # ./input_files/10-GE-Proton.yml
 # -----------------------
+ge-proton11-1:
+  Category: runners
+  Sub-category: proton
+  Channel: stable
+  Date: '1782269772'
 ge-proton10-34:
   Category: runners
   Sub-category: proton

--- a/input_files/10-GE-Proton.yml
+++ b/input_files/10-GE-Proton.yml
@@ -1,3 +1,8 @@
+ge-proton11-1:
+  Category: runners
+  Sub-category: proton
+  Channel: stable
+  Date: '1782269772'
 ge-proton10-34:
   Category: runners
   Sub-category: proton

--- a/runners/proton/ge-proton11-1.yml
+++ b/runners/proton/ge-proton11-1.yml
@@ -1,0 +1,14 @@
+Name: ge-proton11-1
+Provider: GloriousEggroll
+Maintainer: CI
+Channel: stable
+File:
+- file_name: GE-Proton11-1.tar.gz
+  url: https://github.com/GloriousEggroll/proton-ge-custom/releases/download/GE-Proton11-1/GE-Proton11-1.tar.gz
+  file_checksum: dffd78c5f12edd8951ee0ad526533b2d
+  file_size: 528882426
+  rename: GE-Proton11-1.tar.gz
+Post:
+- action: rename
+  source: GE-Proton11-1
+  dest: ge-proton11-1


### PR DESCRIPTION
I've dropped the wrong commit from the `ci/main` branch and rerun CI to unblock #542, but strangely `ge-proton11-1` wasn't picked again on the rerun, so I'm adding it manually here.

## Type of change
- [x] New component
- [ ] Manifest fix
- [ ] Other

## Was this tested using a [Local Repository](https://maintainers.usebottles.com/Testing)?
- [x] Yes
- [ ] No
